### PR TITLE
defining the m2e lifecycle-mappings for eclipse

### DIFF
--- a/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,18 @@
+<lifecycleMappingMetadata>
+	<pluginExecutions>
+		<pluginExecution>
+			<pluginExecutionFilter>
+				<goals>
+					<goal>generate</goal>
+				</goals>
+			</pluginExecutionFilter>
+			<action>
+				<!-- <ignore /> -->
+				<execute>
+					<runOnIncremental>true</runOnIncremental>
+					<runOnConfiguration>true</runOnConfiguration>
+				</execute>
+			</action>
+		</pluginExecution>
+	</pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
by defining the m2e lifecycle-mappings for eclipse, a project using this plugin and imported into eclipse will not show an error message.
please also see: http://wiki.eclipse.org/M2E_compatible_maven_plugins

as soon as this is integrated, the parent jenkins pom for plugins should be updated to use this version.
