### PR TITLE
add "project.build.sourceEncoding" as default for "outputEncoding"

### DIFF
--- a/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorMojo.java
+++ b/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorMojo.java
@@ -71,7 +71,8 @@ public class GeneratorMojo extends AbstractMojo {
      * The charset encoding of generated Java sources.
      * Default to the platform specific encoding.
      *
-     * @parameter
+     * @parameter default-value="${project.build.sourceEncoding}"
+     * @required
      */
     protected String outputEncoding;
 


### PR DESCRIPTION
I think its good to define the encoding to maven settings because you get to much trouble if platform encoding and maven project encoding is different.

Fallback is allways the platform encoding.
