### PR TITLE
[JENKINS-4409] Disable URLClassLoader cache before opening stream

### DIFF
--- a/lib/src/main/java/org/jvnet/localizer/ResourceBundleHolder.java
+++ b/lib/src/main/java/org/jvnet/localizer/ResourceBundleHolder.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.io.ObjectStreamException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -107,7 +108,9 @@ public final class ResourceBundleHolder implements Serializable {
             if(res!=null) {
                 // found property file for this locale.
                 try {
-                    InputStream is = res.openStream();
+                    URLConnection uc = res.openConnection();
+                    uc.setUseCaches(false);
+                    InputStream is = uc.getInputStream();
                     ResourceBundleImpl bundle = new ResourceBundleImpl(is);
                     is.close();
                     rb = bundle;


### PR DESCRIPTION
This commit implements a workaround for https://bugs.openjdk.java.net/browse/JDK-8013099

The previous behaviour was causing retention of file handles, resulting
in temp folder leaks when executing Jenkins test cases.