### PR TITLE
Add support for access-modifier

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -51,5 +51,10 @@
       <artifactId>localizer</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>1.4</version>
+    </dependency>
   </dependencies>
 </project>

--- a/maven-plugin/src/main/java/org/jvnet/localizer/Generator.java
+++ b/maven-plugin/src/main/java/org/jvnet/localizer/Generator.java
@@ -32,6 +32,8 @@ import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 import org.apache.commons.lang3.text.WordUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.File;
 import java.text.DateFormat;
@@ -73,6 +75,9 @@ public class Generator extends CodeModelGenerator implements ClassGenerator {
         try {
             JDefinedClass c = cm._class(className);
             c.annotate(SuppressWarnings.class).paramArray("value").param("").param("PMD").param("all");
+            if (accessModifierAnnotations) {
+                c.annotate(Restricted.class).param("value", NoExternalUse.class);
+            }
             c.javadoc().add("Generated localization support class.");
 
             // [RESULT]

--- a/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorBase.java
+++ b/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorBase.java
@@ -45,6 +45,7 @@ public abstract class GeneratorBase implements ClassGenerator {
     protected final Reporter reporter;
     protected final Pattern keyPattern;
     protected final boolean strictTypes;
+    protected final boolean accessModifierAnnotations;
 
     public GeneratorBase(GeneratorConfig config) {
         outputDirectory = config.getOutputDirectory();
@@ -52,6 +53,7 @@ public abstract class GeneratorBase implements ClassGenerator {
         reporter = config.getReporter();
         keyPattern = config.getKeyPattern();
         strictTypes = config.isStrictTypes();
+        accessModifierAnnotations = config.isAccessModifierAnnotations();
     }
 
     public void generate(File baseDir, DirectoryScanner ds, FileFilter filter) throws IOException {

--- a/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorConfig.java
+++ b/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorConfig.java
@@ -10,6 +10,15 @@ public class GeneratorConfig {
     private Reporter reporter;
     private Pattern keyPattern;
     private boolean strictTypes;
+    private boolean accessModifierAnnotations;
+
+    public boolean isAccessModifierAnnotations() {
+        return accessModifierAnnotations;
+    }
+
+    public void setAccessModifierAnnotations(boolean accessModifierAnnotations) {
+        this.accessModifierAnnotations = accessModifierAnnotations;
+    }
 
     public File getOutputDirectory() {
         return outputDirectory;
@@ -65,12 +74,18 @@ public class GeneratorConfig {
     }
     public static GeneratorConfig of(File outputDirectory, String outputEncoding,
             Reporter reporter, String keyPattern, boolean strictTypes) {
+        return of(outputDirectory, outputEncoding, reporter, keyPattern, strictTypes, false);
+    }
+
+    public static GeneratorConfig of(File outputDirectory, String outputEncoding,
+                                     Reporter reporter, String keyPattern, boolean strictTypes, boolean accessModifierAnnotations) {
         GeneratorConfig config = new GeneratorConfig();
         config.setOutputDirectory(outputDirectory);
         config.setOutputEncoding(outputEncoding);
         config.setReporter(reporter);
         config.setKeyPattern(keyPattern);
         config.setStrictTypes(strictTypes);
+        config.setAccessModifierAnnotations(accessModifierAnnotations);
         return config;
     }
 }

--- a/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorMojo.java
+++ b/maven-plugin/src/main/java/org/jvnet/localizer/GeneratorMojo.java
@@ -100,6 +100,13 @@ public class GeneratorMojo extends AbstractMojo {
      */
     protected boolean strictTypes;
 
+    /**
+     * Whether to annotate Localizer-generated classes with @Restricted(NoExternalUse.class) from access-modifier
+     *
+     * @parameter
+     */
+    protected boolean accessModifierAnnotations;
+
     @SuppressWarnings("unchecked")
     public void execute() throws MojoExecutionException, MojoFailureException {
         String pkg = project.getPackaging();
@@ -111,7 +118,7 @@ public class GeneratorMojo extends AbstractMojo {
                     public void debug(String msg) {
                         getLog().debug(msg);
                     }
-                }, keyPattern, strictTypes);
+                }, keyPattern, strictTypes, accessModifierAnnotations);
         ClassGenerator g = createGenerator(config);
 
         for(Resource res : (List<Resource>)project.getResources()) {


### PR DESCRIPTION
This allows projects using Localizer to indicate that generated classes are not part of their public API.

Fixes #10.
