### PR TITLE
[JENKINS-41729] Allow UTF-8 property files

### DIFF
--- a/lib/src/main/java/org/jvnet/localizer/ResourceBundleHolder.java
+++ b/lib/src/main/java/org/jvnet/localizer/ResourceBundleHolder.java
@@ -25,8 +25,10 @@ package org.jvnet.localizer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.io.ObjectStreamException;
+import java.io.Reader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.text.MessageFormat;
@@ -111,7 +113,9 @@ public final class ResourceBundleHolder implements Serializable {
                     URLConnection uc = res.openConnection();
                     uc.setUseCaches(false);
                     InputStream is = uc.getInputStream();
-                    ResourceBundleImpl bundle = new ResourceBundleImpl(is);
+                    InputStreamReader isr = new InputStreamReader(is, "UTF-8");
+                    ResourceBundleImpl bundle = new ResourceBundleImpl(isr);
+                    isr.close();
                     is.close();
                     rb = bundle;
                     if(next!=null)
@@ -143,6 +147,10 @@ public final class ResourceBundleHolder implements Serializable {
     static class ResourceBundleImpl extends PropertyResourceBundle {
         ResourceBundleImpl(InputStream stream) throws IOException {
             super(stream);
+        }
+
+        ResourceBundleImpl(Reader reader) throws IOException {
+            super(reader);
         }
 
         protected void setParent(ResourceBundle parent) {

--- a/lib/src/test/java/foo/LocaleTest.java
+++ b/lib/src/test/java/foo/LocaleTest.java
@@ -27,7 +27,7 @@ public class LocaleTest extends TestCase {
         assertEquals("german",h.get(Locale.GERMAN).getString("abc"));
     }
 
-    public void testUtf8() throws Exception {
+    public void testEncoded() throws Exception {
         Locale.setDefault(Locale.JAPANESE);
         @SuppressWarnings("deprecation")        // not to use a cache.
         ResourceBundleHolder h = new ResourceBundleHolder(LocaleTest.class);

--- a/lib/src/test/java/foo/LocaleTest.java
+++ b/lib/src/test/java/foo/LocaleTest.java
@@ -26,4 +26,12 @@ public class LocaleTest extends TestCase {
         assertEquals("german",h.get(Locale.GERMANY).getString("abc"));
         assertEquals("german",h.get(Locale.GERMAN).getString("abc"));
     }
+
+    public void testUtf8() throws Exception {
+        Locale.setDefault(Locale.JAPANESE);
+        @SuppressWarnings("deprecation")        // not to use a cache.
+        ResourceBundleHolder h = new ResourceBundleHolder(LocaleTest.class);
+        assertEquals("日本語", h.format("abc"));
+    }
+
 }

--- a/lib/src/test/java/foo/Utf8LocaleTest.java
+++ b/lib/src/test/java/foo/Utf8LocaleTest.java
@@ -1,0 +1,19 @@
+package foo;
+
+import junit.framework.TestCase;
+
+import java.util.Locale;
+
+import org.jvnet.localizer.ResourceBundleHolder;
+
+/**
+ * @author IKEDA Yasuyuki
+ */
+public class Utf8LocaleTest extends TestCase {
+    public void testUtf8() throws Exception {
+        Locale.setDefault(Locale.JAPANESE);
+        @SuppressWarnings("deprecation")        // not to use a cache.
+        ResourceBundleHolder h = new ResourceBundleHolder(Utf8LocaleTest.class);
+        assertEquals("日本語", h.format("abc"));
+    }
+}

--- a/lib/src/test/resources/foo/LocaleTest_ja.properties
+++ b/lib/src/test/resources/foo/LocaleTest_ja.properties
@@ -1,0 +1,2 @@
+# "Japanese" in Japanese
+abc=日本語

--- a/lib/src/test/resources/foo/LocaleTest_ja.properties
+++ b/lib/src/test/resources/foo/LocaleTest_ja.properties
@@ -1,2 +1,3 @@
 # "Japanese" in Japanese
-abc=日本語
+# abc=日本語
+abc=\u65e5\u672c\u8a9e

--- a/lib/src/test/resources/foo/Utf8LocaleTest.properties
+++ b/lib/src/test/resources/foo/Utf8LocaleTest.properties
@@ -1,0 +1,1 @@
+abc=base

--- a/lib/src/test/resources/foo/Utf8LocaleTest_ja.properties
+++ b/lib/src/test/resources/foo/Utf8LocaleTest_ja.properties
@@ -1,0 +1,2 @@
+# "Japanese" in Japanese
+abc=日本語

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,12 @@
     <!--module>test</module-->
   </modules>
 
+  <properties>
+    <java.level>6</java.level>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <scm>
     <connection>scm:git:git@github.com/kohsuke/localizer.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/kohsuke/localizer.git</developerConnection>
@@ -30,8 +36,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.${java.level}</source>
+          <target>1.${java.level}</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
[JENKINS-41729](https://issues.jenkins-ci.org/browse/JENKINS-41729)

It's difficult to review localization pull requests for Jenkins plugins in github, as property files are encoded.
I have to review them in IDE.

This change makes localizer accept UTF-8 property files, and property files no longer need to be encoded.

Actually, I'm not sure accepting UTF-8 files is the best approach, and I want comments about this change.
