### PR TITLE
Make this plugin artifact independent from jenkins-ci repositories

### DIFF
--- a/maven-plugin/.gitignore
+++ b/maven-plugin/.gitignore
@@ -1,0 +1,1 @@
+/dependency-reduced-pom.xml

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jvnet.localizer</groupId>
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-annotation</artifactId>
-      <version>1.4</version>
+      <version>1.26</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -129,6 +129,29 @@
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+          <artifactSet>
+          	<includes>
+          	  <include>org.kohsuke:access-modifier-annotation</include>
+          	  <include>org.jenkins-ci:annotation-indexer</include>
+          	</includes>
+          </artifactSet>
+          <shadeSourcesContent>true</shadeSourcesContent>
+          <useDependencyReducedPomInJar>true</useDependencyReducedPomInJar>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Make this plugin artifact independent from jenkins-ci repositories using maven shade plugin to include indexer and its dependencies. This avoid in other project to require include jenkins repositories